### PR TITLE
feat: add color and summary statistics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Install and Run Application
+name: Run tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -134,17 +134,17 @@ If you have files that don't match the expected naming pattern, you'll see a war
 ⚠️  WARNING: The following files do not match the expected pattern:
 Expected pattern: <yyyy-mm-dd> - <description> - $<amount>.<ext>
 
-Filename                                                         Error
---------                                                         -----
-2021-01-10 - doctor-incorrect-amount - $50,00.pdf                Amount "$50,00.pdf" should be a valid format like $50.00
-2021-01-10 - doctor-incorrect-amount - $50.pdf                   Amount "$50.pdf" should be a valid format like $50.00
-2021-01-15 - doctor-missing-dollar-sign - 50.00.pdf              Amount "50.00.pdf" should start with $
-2021-01-25 - doctor-no-extension - $50.00                        File is missing extension (should end with .pdf, .jpg, etc.)
-2021-01-30 - doctor-missing-amount.pdf                                  File name should have format "yyyy-mm-dd - description - $amount.ext"
-2021-01-30- doctor-missing-space-after-dash - $50.00.pdf         File name should have format "yyyy-mm-dd - description - $amount.ext"
-2021-1-25 - doctor-wrong-date-format - $50.00.pdf                Date "2021-1-25" should be yyyy-mm-dd format
-2021-25-01 - doctor-wrong-date-format - $50.00.pdf               Date "2021-25-01" should be yyyy-mm-dd format
-doctor-missing-date - $120.00.pdf                                File name should have format "yyyy-mm-dd - description - $amount.ext"
+Filename                                                     Error
+--------                                                     -----
+2021-01-10 - doctor-incorrect-amount - $50,00.pdf            Amount "$50,00.pdf" should be a valid format like $50.00
+2021-01-10 - doctor-incorrect-amount - $50.pdf               Amount "$50.pdf" should be a valid format like $50.00
+2021-01-15 - doctor-missing-dollar-sign - 50.00.pdf          Amount "50.00.pdf" should start with $
+2021-01-25 - doctor-no-extension - $50.00                    File is missing extension (should end with .pdf, .jpg, etc.)
+2021-01-30 - doctor-missing-amount.pdf                       File name should have format "yyyy-mm-dd - description - $amount.ext"
+2021-01-30- doctor-missing-space-before-dash - $50.00.pdf    File name should have format "yyyy-mm-dd - description - $amount.ext"
+2021-1-25 - doctor-wrong-date-format - $50.00.pdf            Date "2021-1-25" should be yyyy-mm-dd format
+2021-25-01 - doctor-wrong-date-format - $50.00.pdf           Date "2021-25-01" should be yyyy-mm-dd format
+doctor-missing-date - $120.00.pdf                            File name should have format "yyyy-mm-dd - description - $amount.ext"
 ```
 
 [ci]: https://github.com/joshjohanning/hsa-expense-analyzer-cli/actions/workflows/ci.yml

--- a/main.js
+++ b/main.js
@@ -152,12 +152,16 @@ if (years.length === 0) {
 
 // Display any invalid files
 if (invalidFiles.length > 0) {
+  // Calculate dynamic padding based on longest filename + buffer
+  const maxFileNameLength = Math.max(...invalidFiles.map(f => f.fileName.length));
+  const padding = Math.max(maxFileNameLength + 4, 'Filename'.length + 4); // At least header width + buffer
+  
   console.log("⚠️  WARNING: The following files do not match the expected pattern:");
   console.log("Expected pattern: <yyyy-mm-dd> - <description> - $<amount>.<ext>");
-  console.log("\nFilename".padEnd(65) + " Error");
-  console.log("--------".padEnd(65) + "-----");
+  console.log("\nFilename".padEnd(padding) + " Error");
+  console.log("--------".padEnd(padding) + "-----");
   invalidFiles.forEach(({ fileName, error }) => {
-    console.log(fileName.padEnd(65) + error);
+    console.log(fileName.padEnd(padding) + error);
   });
   console.log();
 }

--- a/main.js
+++ b/main.js
@@ -302,3 +302,41 @@ for (const year of years) {
   console.log(`${year} Reimbursements ╢${reimbursementBar} $${reimbursementAmount.toFixed(2)}`);}
 
 console.log("                    ╚════════════════════");
+console.log();
+
+// Summary statistics
+console.log("📊 Summary Statistics");
+console.log("━".repeat(50));
+
+const totalValidFiles = Object.values(receiptCounts).reduce((sum, count) => sum + count, 0);
+const totalInvalidFiles = invalidFiles.length;
+const totalFiles = totalValidFiles + totalInvalidFiles;
+const invalidFilePercentage = totalFiles > 0 ? ((totalInvalidFiles / totalFiles) * 100).toFixed(1) : 0;
+const avgExpensePerYear = years.length > 0 ? (totalExpenses / years.length).toFixed(2) : 0;
+const avgReceiptsPerYear = years.length > 0 ? Math.round(totalValidFiles / years.length) : 0;
+const reimbursementRate = totalExpenses > 0 ? ((totalReimbursements / totalExpenses) * 100).toFixed(1) : 0;
+const totalReimburseable = totalExpenses - totalReimbursements; // Money you could still get reimbursed
+const reimburseableRate = totalExpenses > 0 ? ((totalReimburseable / totalExpenses) * 100).toFixed(1) : 0;
+
+console.log(`${colorize('Total Receipts Processed:', 'cyan')} ${totalFiles}`);
+if (totalInvalidFiles > 0) {
+  console.log(`${colorize('Invalid Receipts:', 'yellow')} ${totalInvalidFiles} (${invalidFilePercentage}%)`);
+}
+console.log(`${colorize('Years Covered:', 'cyan')} ${years.length} (${years[0]} - ${years[years.length - 1]})`);
+console.log(`${colorize('Total Expenses:', 'cyan')} $${totalExpenses.toFixed(2)}`);
+console.log(`${colorize('Total Reimbursements:', 'cyan')} $${totalReimbursements.toFixed(2)} (${reimbursementRate}%)`);
+console.log(`${colorize('Total Reimburseable:', 'green')} $${totalReimburseable.toFixed(2)} (${reimburseableRate}%)`);
+console.log(`${colorize('Average Expenses/Year:', 'cyan')} $${avgExpensePerYear}`);
+console.log(`${colorize('Average Receipts/Year:', 'cyan')} ${avgReceiptsPerYear}`);
+
+// Find the most expensive year
+if (years.length > 0) {
+  const mostExpensiveYear = years.reduce((maxYear, year) => 
+    (expensesByYear[year] || 0) > (expensesByYear[maxYear] || 0) ? year : maxYear
+  );
+  const mostExpensiveYearReceipts = receiptCounts[mostExpensiveYear] || 0;
+  const mostExpensiveYearAmount = expensesByYear[mostExpensiveYear] || 0;
+  const expensePercentage = totalExpenses > 0 ? ((mostExpensiveYearAmount / totalExpenses) * 100).toFixed(1) : 0;
+  const receiptPercentage = totalValidFiles > 0 ? ((mostExpensiveYearReceipts / totalValidFiles) * 100).toFixed(1) : 0;
+  console.log(`${colorize('Most Expensive Year:', 'cyan')} ${mostExpensiveYear} ($${mostExpensiveYearAmount.toFixed(2)} [${expensePercentage}%], ${mostExpensiveYearReceipts} receipts [${receiptPercentage}%])`);
+}

--- a/main.js
+++ b/main.js
@@ -154,7 +154,8 @@ if (years.length === 0) {
 if (invalidFiles.length > 0) {
   // Calculate dynamic padding based on longest filename + buffer
   const maxFileNameLength = Math.max(...invalidFiles.map(f => f.fileName.length));
-  const padding = Math.max(maxFileNameLength + 4, 'Filename'.length + 4); // At least header width + buffer
+  const paddingAmount = 4;
+  const padding = Math.max(maxFileNameLength + paddingAmount, 'Filename'.length + paddingAmount);
   
   console.log("⚠️  WARNING: The following files do not match the expected pattern:");
   console.log("Expected pattern: <yyyy-mm-dd> - <description> - $<amount>.<ext>");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@joshjohanning/hsa-expense-analyzer-cli",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@joshjohanning/hsa-expense-analyzer-cli",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chartscii": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@joshjohanning/hsa-expense-analyzer-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@joshjohanning/hsa-expense-analyzer-cli",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "chartscii": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshjohanning/hsa-expense-analyzer-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A Node.js CLI tool that analyzes HSA expenses and reimbursements by year from a folder of receipt files.",
   "keywords": [
     "hsa",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshjohanning/hsa-expense-analyzer-cli",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "A Node.js CLI tool that analyzes HSA expenses and reimbursements by year from a folder of receipt files.",
   "keywords": [
     "hsa",

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ console.log('Running hsa-expense-analyzer-cli tests...\n');
 
 try {
   // Run the main script on test-data directory and capture output
-  const output = execSync('node main.js --dirPath=test-data/', { 
+  const output = execSync('node main.js --dirPath=test-data/ --no-color', { 
     encoding: 'utf8',
     cwd: __dirname 
   });
@@ -40,7 +40,7 @@ try {
     // Strip ANSI color codes for easier parsing
     const cleanLine = line.replace(/\x1b\[[0-9;]*m/g, '');
     
-    if (cleanLine.includes('⚠️  WARNING: The following files do not match the expected pattern:')) {
+    if (cleanLine.includes('⚠️  WARNING: The following files do not match the expected pattern')) {
       inErrorSection = true;
       continue;
     }

--- a/test.js
+++ b/test.js
@@ -65,6 +65,7 @@ try {
   
   // Test validation at the end
   console.log('='.repeat(80));
+  console.log();
   console.log('TEST VALIDATION:');
   
   let testsPassed = 0;


### PR DESCRIPTION
**CLI Output and User Experience Improvements:**

* Added ANSI color codes for improved terminal output and a `--no-color` option to disable colored output in `main.js`. This affects error messages, warnings, and summary statistics for better readability. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR10-R19) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR31-R35) [[3]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aR47-R55)
* Enhanced error and warning messages to use color, and dynamically calculated column widths for displaying invalid files, making the output more readable and professional. [[1]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL103-R128) [[2]](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL148-R190)

**Summary and Statistics:**

* Added a summary statistics section at the end of the CLI output, including total receipts, invalid files, years covered, totals and averages, and highlights such as the most expensive year.

**Testing and CI:**

* Updated the test script to use the `--no-color` flag for easier output parsing, and improved error section detection. [[1]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L16-R16) [[2]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60L43-R43) [[3]](diffhunk://#diff-13876b4beb64b9f156474dc78f9c923952a7ca210d4507b6b3135bbe244f8a60R68)
* Renamed the CI workflow step from "Install and Run Application" to "Run tests" for clarity in `.github/workflows/ci.yml`.

**Documentation and Versioning:**

* Corrected a filename description in `README.md` for clarity and accuracy.
* Bumped the package version to `0.2.0` in `package.json` to reflect these feature improvements.